### PR TITLE
Add optional parameter "season" for players feed

### DIFF
--- a/ohmysportsfeedspy/v1_0.py
+++ b/ohmysportsfeedspy/v1_0.py
@@ -150,7 +150,10 @@ class API_v1_0(object):
             if str(key) == 'league':
                 league = value
             elif str(key) == 'season':
-                season = value
+                if kwargs['feed'] == 'players':
+                    params['season'] = value
+                else:
+                    season = value
             elif str(key) == 'feed':
                 feed = value
             elif str(key) == 'format':


### PR DESCRIPTION
The v2.0 API docs list 'season' as an optional parameter for the players feed. The v2_0.py determine_url() method removes season from the header for the players feed but didn't add it to the request parameters dict, so the wrapper was ignoring that parameter.