### PR TITLE
change how HTTP response code is returned to make it easier to parse, add comment to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,4 +79,14 @@ Example (v2.x): Get full game schedule and scores for the MLB 2016 playoff seaso
     output = msf.msf_get_data(league='mlb',season='2016-playoff',feed='seasonal_games',format='csv')
 ```
 
+Non-successful response codes can be handled using a snippet like below:
+
+```python
+try:
+    output = msf.get_data(...)
+except Warning as e:
+    status_code = e.args[1]
+    ... # Add logic to handle status codes other than 200 and 304 here
+```
+
 That's it!  Returned data is also stored locally under "results/" by default, in appropriately named files.

--- a/ohmysportsfeedspy/v1_0.py
+++ b/ohmysportsfeedspy/v1_0.py
@@ -208,6 +208,6 @@ class API_v1_0(object):
                     data = f.read().splitlines()
 
         else:
-            raise Warning("API call failed with error: {error}".format(error=r.status_code))
+            raise Warning("API call failed with error:", r.status_code)
 
         return data


### PR DESCRIPTION
In my code I wanted to parse the HTTP response code so that I could decide how to handle it. Right now I am slicing out the last three characters of the Warning string and casting it to an integer, but that felt like a hack.

This change gives users the same message but makes it easier to grab the status code, and I included some example code in the README