### PR TITLE
Add install_requires to setup.py for pip install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,2 @@
-requests==2.12.4
-simplejson==3.10.0
-py==1.4.32
+.
 pytest==3.0.5
-python-dateutil==2.6.0
-simplejson==3.16.0

--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,10 @@ setup(
     author_email='brad.barkhouse@mysportsfeeds.com',
     url='https://github.com/MySportsFeeds/mysportsfeeds-python',
     license='MIT',
-    description='A Python wrapper for the MySportsFeeds Sports Data API'
+    description='A Python wrapper for the MySportsFeeds Sports Data API',
+    install_requires=[
+        'requests>=2,<3',
+        'simplejson>=3,<4',
+        'python-dateutil>=2,<3',
+    ]
 )


### PR DESCRIPTION
Currently, when you install the package via "pip install
ohmysportsfeedspy", it doesn't install any of the requirements.
By moving the requirements into the setup.py, this problem will be
fixed. These versions should be as loose as possible for dependency
resolution.

Using the "." in requirements.txt will enable the existing make commands
to work.