### PR TITLE
Add a weekly game lines feed to the python API

### DIFF
--- a/ohmysportsfeedspy/v2_1.py
+++ b/ohmysportsfeedspy/v2_1.py
@@ -48,6 +48,7 @@ class API_v2_1(API_v1_0):
             'seasonal_standings',
             'seasonal_game_lines',
             'daily_game_lines',
+            'weekly_game_lines',
             'daily_futures'
         ]
 
@@ -239,6 +240,14 @@ class API_v2_1(API_v1_0):
                 raise AssertionError("You must specify a 'date' param for this request.")
             return "{base_url}/{league}/{season}/date/{date}/odds_gamelines.{output}".format(base_url=self.base_url, league=league,
                                                                                              season=season, date=params["date"], output=output_format)
+
+        elif feed == "weekly_game_lines":
+            if season == "":
+                raise AssertionError("You must specify a season for this request")
+            if not "week" in params:
+                raise AssertionError("You must specify a 'week' param for this request.")
+            week = params['week']
+            return f"{self.base_url}/{league}/{season}/week/{week}/odds_gamelines.{output_format}"
 
         elif feed == "daily_futures":
             if season == "":

--- a/ohmysportsfeedspy/v2_1.py
+++ b/ohmysportsfeedspy/v2_1.py
@@ -246,6 +246,8 @@ class API_v2_1(API_v1_0):
                 raise AssertionError("You must specify a season for this request")
             if not "week" in params:
                 raise AssertionError("You must specify a 'week' param for this request.")
+            if league != "nfl":
+                raise AssertionError("weekly_game_lines feed type only avaiable for the NFL")
             week = params['week']
             return f"{self.base_url}/{league}/{season}/week/{week}/odds_gamelines.{output_format}"
 


### PR DESCRIPTION
This feed type exists in the API (https://www.mysportsfeeds.com/data-feeds/api-docs/#) and should have an entry here. This PR adds that feed type, and exposes the weekly feed data in accordance with the API docs.

```
>>> msf
<ohmysportsfeedspy.MySportsFeeds_API.MySportsFeeds object at 0x102506790>
>>> msf.version
'2.1'
>>> resp = msf.msf_get_data(league='nfl', season='2021-2022-regular', week=18, feed='weekly_game_lines', format='json')
    URL TO CALL https://api.mysportsfeeds.com/v2.1/pull/nfl/2021-2022-regular/week/18/odds_gamelines.json
>>> resp.keys()
dict_keys(['lastUpdatedOn', 'gameLines', 'references'])
>>> len(resp['gameLines'])
16
```